### PR TITLE
fix for random-1.0.1.0

### DIFF
--- a/HCodecs.cabal
+++ b/HCodecs.cabal
@@ -1,5 +1,5 @@
 name: HCodecs
-version: 0.2
+version: 0.2.1
 cabal-Version: >= 1.2
 license: BSD3
 license-file: LICENSE

--- a/src/Data/Arbitrary.hs
+++ b/src/Data/Arbitrary.hs
@@ -13,7 +13,7 @@
 --
 -----------------------------------------------------------------------------
 
-{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleContexts, CPP #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Data.Arbitrary (
@@ -36,6 +36,9 @@ import Data.Array.IArray
 
 import System.Random
 
+-- random since 1.0.1.0 defines the following instances
+#if MIN_VERSION_random(1,0,1)
+#else
 
 instance Random Word8 where
   randomR = integralRandomR
@@ -72,6 +75,7 @@ instance Random Word64 where
 instance Random Int64 where
   randomR = integralRandomR
   random = randomR (minBound,maxBound)
+#endif
 
 integralRandomR :: (Integral a, RandomGen g) => (a,a) -> g -> (a,g)
 integralRandomR  (a,b) g = case randomR (fromIntegral a :: Integer,fromIntegral b :: Integer) g of


### PR DESCRIPTION
Hi, 

I made a small fix to make the library build with new version of random library. It now includes many more random instances, so the ones included in HCodecs should not be used then.
