### PR TITLE
Update Audio.hs

### DIFF
--- a/src/Data/Audio.hs
+++ b/src/Data/Audio.hs
@@ -41,6 +41,7 @@ import Data.Int
 
 import Data.Array.Unboxed
 import Data.Array.IO
+import Data.Array.Unsafe
 
 import Data.Monoid
 


### PR DESCRIPTION
HCodecs doesn't compile without Data.Array.Unsafe in GHC 7.8.2
