### PR TITLE
Fix build due to Monoid-Semigroup proposal in GHC 8.4

### DIFF
--- a/HCodecs.cabal
+++ b/HCodecs.cabal
@@ -46,5 +46,12 @@ test-suite tests
   type: exitcode-stdio-1.0
   hs-source-dirs: src
   ghc-options: -O3 -Wall
-  build-depends: base < 5, bytestring, random, array >= 0.4, QuickCheck >= 2.0
+  build-depends:
+      base < 5
+    , bytestring
+    , random
+    , semigroups
+    , array >= 0.4
+    , QuickCheck >= 2.0
+
   main-is: Codec/Internal/TestSuite.hs

--- a/HCodecs.cabal
+++ b/HCodecs.cabal
@@ -24,7 +24,14 @@ source-repository head
 library
   hs-source-dirs: src
   ghc-options: -O3 -Wall
-  build-depends: base < 5, bytestring, random, array >= 0.4, QuickCheck >= 2.0
+  build-depends:
+      base             <  5
+    , bytestring
+    , random
+    , semigroups
+    , array            >= 0.4
+    , QuickCheck       >= 2.0
+
   exposed-modules:
     Codec.Midi
     Codec.Wav

--- a/src/Codec/ByteString/Builder.hs
+++ b/src/Codec/ByteString/Builder.hs
@@ -76,7 +76,8 @@ import Data.ByteString.Internal (inlinePerformIO,c2w)
 import Data.Bits
 import Data.Word
 import Data.Int
-import Data.Monoid
+import Data.Monoid hiding ((<>))
+import Data.Semigroup
 
 ------------------------------------------------------------------------
 
@@ -96,9 +97,12 @@ newtype Builder = Builder {
         runBuilder :: (Buffer -> [S.ByteString]) -> Buffer -> [S.ByteString]
     }
 
+instance Semigroup Builder where
+    (<>) = append
+
 instance Monoid Builder where
     mempty  = empty
-    mappend = append
+    mappend = (<>)
 
 ------------------------------------------------------------------------
 


### PR DESCRIPTION
There are still a bunch of warnings, but at least it builds on the latest GHC (and older versions).